### PR TITLE
High-fidelity page screenshots: viewport 1920×1080, DPR 2, ready-detector + lazy-trigger + orchestrator

### DIFF
--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -466,7 +466,7 @@ export async function buildServer(): Promise<FastifyInstance> {
     const job = await crawlQueue.add("crawl", {
       url, publicUrl,
       maxRequestsPerCrawl,
-      deviceScaleFactor: deviceScaleFactor || 1,
+      deviceScaleFactor: deviceScaleFactor || 2,
       delay: delay || 0,
       requestDelay: requestDelay || 1000,
       maxDepth: maxDepth === undefined ? 0 : maxDepth,
@@ -516,7 +516,7 @@ export async function buildServer(): Promise<FastifyInstance> {
     const job = await crawlQueue.add("recrawl-page", {
       url, publicUrl,
       maxRequestsPerCrawl: 1,
-      deviceScaleFactor: deviceScaleFactor || 1,
+      deviceScaleFactor: deviceScaleFactor || 2,
       delay: delay || 0,
       requestDelay: requestDelay || 1000,
       maxDepth: 0,
@@ -604,7 +604,7 @@ export async function buildServer(): Promise<FastifyInstance> {
       url: startUrl,
       publicUrl,
       maxRequestsPerCrawl: normalizedApprovedUrls.length,
-      deviceScaleFactor: body.deviceScaleFactor || 1,
+      deviceScaleFactor: body.deviceScaleFactor || 2,
       requestDelay: 1000,
       maxDepth: 0,
       defaultLanguageOnly: false,

--- a/packages/backend/src/crawler.ts
+++ b/packages/backend/src/crawler.ts
@@ -1477,7 +1477,7 @@ export async function runCrawler(
       "Sec-Ch-Ua-Platform": '"macOS"',
       "Upgrade-Insecure-Requests": "1",
     });
-    await page.setViewportSize({ width: 1440, height: 900 }).catch(() => undefined);
+    await page.setViewportSize({ width: 1920, height: 1080 }).catch(() => undefined);
     await page.addInitScript(() => {
       Object.defineProperty(navigator, "webdriver", { get: () => false });
     }).catch(() => undefined);
@@ -1884,6 +1884,10 @@ export async function runCrawler(
           log.info(`Extracted ${styleData.elements.length} elements and ${Object.keys(styleData.cssVariables).length} CSS variables`);
         }
 
+        const captureViewport = page.viewportSize();
+        log.info(
+          `📸 Capturing ${finalUrl} at viewport ${captureViewport?.width ?? "?"}x${captureViewport?.height ?? "?"}`
+        );
         const fullPageBuffer = await page.screenshot({ fullPage: true });
 
         await updateProgress("processing", currentPage, totalPages, finalUrl);
@@ -2411,7 +2415,7 @@ export async function openAuthSession(url: string): Promise<{
 
   const context = await browser.newContext({
     userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
-    viewport: { width: 1440, height: 900 },
+    viewport: { width: 1920, height: 1080 },
     locale: "en-US",
     timezoneId: "America/New_York",
   });

--- a/packages/backend/src/crawler.ts
+++ b/packages/backend/src/crawler.ts
@@ -1258,7 +1258,7 @@ export async function runCrawler(
   startUrl: string,
   publicUrl: string,
   maxRequestsPerCrawl?: number,
-  deviceScaleFactor: number = 1,
+  deviceScaleFactor: number = 2,
   jobId?: string,
   delay: number = 0,
   requestDelay: number = 1000,
@@ -1479,7 +1479,9 @@ export async function runCrawler(
       "Sec-Ch-Ua-Platform": '"macOS"',
       "Upgrade-Insecure-Requests": "1",
     });
-    await page.setViewportSize({ width: 1920, height: 1080 }).catch(() => undefined);
+    // Viewport + DPR are now set at the persistent-context level in
+    // launchContext.launchOptions, so we no longer call setViewportSize here.
+    // Calling it would reset DPR back to 1.
     await page.addInitScript(() => {
       Object.defineProperty(navigator, "webdriver", { get: () => false });
     }).catch(() => undefined);
@@ -1541,7 +1543,6 @@ export async function runCrawler(
       launchContext: {
         launchOptions: {
           args: [
-            ...(deviceScaleFactor > 1 ? ["--device-scale-factor=2"] : []),
             "--disable-infobars",
             "--disable-extensions-except=",
             "--disable-extensions",
@@ -1552,6 +1553,12 @@ export async function runCrawler(
           headless: !showBrowser,
           slowMo: 100,
           devtools: false,
+          // launchPersistentContext accepts BrowserContextOptions alongside
+          // LaunchOptions — this is the only place Crawlee gives us to set
+          // DPR + viewport at context creation. Per-page CDP overrides and
+          // the --device-scale-factor chromium flag are unreliable here.
+          deviceScaleFactor,
+          viewport: { width: 1920, height: 1080 },
         },
         userAgent: randomUserAgent,
       },
@@ -1879,7 +1886,7 @@ export async function runCrawler(
 
         const captureViewport = page.viewportSize();
         log.info(
-          `📸 Capturing ${finalUrl} at viewport ${captureViewport?.width ?? "?"}x${captureViewport?.height ?? "?"}`
+          `📸 Capturing ${finalUrl} at viewport ${captureViewport?.width ?? "?"}x${captureViewport?.height ?? "?"} @ DPR ${deviceScaleFactor}`
         );
 
         const readinessReport = await waitUntilStable(page);
@@ -1993,6 +2000,8 @@ export async function runCrawler(
           try {
             const now = new Date();
 
+            const cssViewportWidth = captureViewport?.width ?? null;
+
             const pageResult = db
               .insert(pages)
               .values({
@@ -2005,6 +2014,7 @@ export async function runCrawler(
                 globalStyles: styleData
                   ? JSON.stringify({ cssVariables: styleData.cssVariables, tokens: styleData.tokens })
                   : null,
+                viewportWidth: cssViewportWidth,
                 lastCrawledAt: now,
                 lastCrawlJobId: jobId ?? null,
                 lastCrawlRunId: crawlRunId ?? null,
@@ -2021,6 +2031,7 @@ export async function runCrawler(
                   globalStyles: styleData
                     ? JSON.stringify({ cssVariables: styleData.cssVariables, tokens: styleData.tokens })
                     : null,
+                  viewportWidth: cssViewportWidth,
                   lastCrawledAt: now,
                   lastCrawlJobId: jobId ?? null,
                   lastCrawlRunId: crawlRunId ?? null,

--- a/packages/backend/src/crawler.ts
+++ b/packages/backend/src/crawler.ts
@@ -9,6 +9,7 @@ import { eq, and, notInArray, inArray } from "drizzle-orm";
 import { categorizeElement } from "./services/inventory/elementCategory.js";
 import { normalizeStyleValue } from "./services/inventory/normalizeStyles.js";
 import { bucketDimension } from "./services/inventory/signatureBuilders.js";
+import { waitUntilStable } from "./services/capture/pageReadyDetector.js";
 
 interface InteractiveElement {
   type: "link" | "button";
@@ -1888,6 +1889,14 @@ export async function runCrawler(
         log.info(
           `📸 Capturing ${finalUrl} at viewport ${captureViewport?.width ?? "?"}x${captureViewport?.height ?? "?"}`
         );
+
+        const readinessReport = await waitUntilStable(page);
+        log.info(
+          `🟢 Readiness for ${finalUrl}: ${Object.entries(readinessReport)
+            .map(([k, v]) => `${k}=${v}`)
+            .join(" ")}`
+        );
+
         const fullPageBuffer = await page.screenshot({ fullPage: true });
 
         await updateProgress("processing", currentPage, totalPages, finalUrl);

--- a/packages/backend/src/crawler.ts
+++ b/packages/backend/src/crawler.ts
@@ -9,8 +9,7 @@ import { eq, and, notInArray, inArray } from "drizzle-orm";
 import { categorizeElement } from "./services/inventory/elementCategory.js";
 import { normalizeStyleValue } from "./services/inventory/normalizeStyles.js";
 import { bucketDimension } from "./services/inventory/signatureBuilders.js";
-import { waitUntilStable } from "./services/capture/pageReadyDetector.js";
-import { triggerLazyContent } from "./services/capture/lazyContentTrigger.js";
+import { captureHighFidelity } from "./services/capture/highFidelityCapture.js";
 
 interface InteractiveElement {
   type: "link" | "button";
@@ -1717,65 +1716,28 @@ export async function runCrawler(
           await page.waitForTimeout(delay);
         }
 
-        await handleCookieConsentBanner(
-          page,
-          cookieBannerHandling,
-          log,
-          finalUrl
-        );
-
-        // Hide extra sticky/fixed elements
-        try {
-          await page.evaluate(() => {
-            const stickyElements = document.querySelectorAll(
-              '[style*="position: fixed"], [style*="position: sticky"], .sticky, .fixed'
-            );
-            stickyElements.forEach((el, index) => {
-              if (index > 0) (el as HTMLElement).style.display = "none";
-            });
-            document.documentElement.style.transform = "none";
-            document.body.style.transform = "none";
-          });
-        } catch { log.info(`Could not handle sticky elements for ${finalUrl}`); }
-
-        // Trigger lazy-loaded content via settle-based scroll-then-wait.
-        try {
-          await triggerLazyContent(page);
-          log.info(`Completed lazy-content trigger for ${finalUrl}`);
-        } catch (error) {
-          log.info(
-            `Lazy-content trigger failed for ${finalUrl}: ${error instanceof Error ? error.message : String(error)}`
-          );
-        }
-
-        await handleCookieConsentBanner(
-          page,
-          cookieBannerHandling,
-          log,
-          finalUrl
-        );
-
         const title = await page.title();
         log.info(`Crawled ${finalUrl} - Title: ${title}`);
 
         await updateProgress("screenshot", currentPage, totalPages, finalUrl);
 
-        // Ensure page is at the top before screenshot
-        try {
-          await page.evaluate(() => {
-            window.scrollTo({ top: 0, behavior: "instant" });
-            document.documentElement.scrollTop = 0;
-            document.body.scrollTop = 0;
-            if (document.scrollingElement) document.scrollingElement.scrollTop = 0;
-          });
-          await page.waitForTimeout(300);
-        } catch { log.info(`⚠️ Could not ensure top position for ${finalUrl}`); }
-
-        await handleCookieConsentBanner(
-          page,
-          cookieBannerHandling,
-          log,
-          finalUrl
+        // Orchestrated visual capture: cookie banners (3 passes) + sticky
+        // element hide + lazy-content trigger + scroll-to-top + readiness
+        // wait + screenshot. See services/capture/highFidelityCapture.ts.
+        const captureResult = await captureHighFidelity(page, {
+          dismissBanners: async () => {
+            await handleCookieConsentBanner(
+              page,
+              cookieBannerHandling,
+              log,
+              finalUrl
+            );
+          },
+        });
+        log.info(
+          `🟢 Readiness for ${finalUrl}: ${Object.entries(captureResult.readinessReport)
+            .map(([k, v]) => `${k}=${v}`)
+            .join(" ")}`
         );
 
         // Interactive elements
@@ -1886,17 +1848,10 @@ export async function runCrawler(
 
         const captureViewport = page.viewportSize();
         log.info(
-          `📸 Capturing ${finalUrl} at viewport ${captureViewport?.width ?? "?"}x${captureViewport?.height ?? "?"} @ DPR ${deviceScaleFactor}`
+          `📸 Captured ${finalUrl} at viewport ${captureViewport?.width ?? "?"}x${captureViewport?.height ?? "?"} @ DPR ${deviceScaleFactor} (raster ${captureResult.width}x${captureResult.height})`
         );
 
-        const readinessReport = await waitUntilStable(page);
-        log.info(
-          `🟢 Readiness for ${finalUrl}: ${Object.entries(readinessReport)
-            .map(([k, v]) => `${k}=${v}`)
-            .join(" ")}`
-        );
-
-        const fullPageBuffer = await page.screenshot({ fullPage: true });
+        const fullPageBuffer = captureResult.buffer;
 
         await updateProgress("processing", currentPage, totalPages, finalUrl);
         const screenshotSlices = await sliceScreenshot(fullPageBuffer, finalUrl, publicUrl);

--- a/packages/backend/src/crawler.ts
+++ b/packages/backend/src/crawler.ts
@@ -10,6 +10,7 @@ import { categorizeElement } from "./services/inventory/elementCategory.js";
 import { normalizeStyleValue } from "./services/inventory/normalizeStyles.js";
 import { bucketDimension } from "./services/inventory/signatureBuilders.js";
 import { waitUntilStable } from "./services/capture/pageReadyDetector.js";
+import { triggerLazyContent } from "./services/capture/lazyContentTrigger.js";
 
 interface InteractiveElement {
   type: "link" | "button";
@@ -1730,24 +1731,15 @@ export async function runCrawler(
           });
         } catch { log.info(`Could not handle sticky elements for ${finalUrl}`); }
 
-        // Scroll to trigger lazy loading
+        // Trigger lazy-loaded content via settle-based scroll-then-wait.
         try {
-          await page.evaluate(async () => {
-            const scrollHeight = document.documentElement.scrollHeight;
-            const viewportHeight = window.innerHeight;
-            let pos = 0;
-            while (pos < scrollHeight) {
-              pos += viewportHeight;
-              window.scrollTo(0, pos);
-              await new Promise((r) => setTimeout(r, Math.min(500, 500)));
-            }
-            window.scrollTo(0, 0);
-            document.documentElement.scrollTop = 0;
-            document.body.scrollTop = 0;
-          });
-          await page.waitForTimeout(delay > 0 ? Math.min(2000, delay / 2) : 1000);
-          log.info(`Completed scrolling through ${finalUrl}`);
-        } catch { log.info(`Scrolling failed or not needed for ${finalUrl}`); }
+          await triggerLazyContent(page);
+          log.info(`Completed lazy-content trigger for ${finalUrl}`);
+        } catch (error) {
+          log.info(
+            `Lazy-content trigger failed for ${finalUrl}: ${error instanceof Error ? error.message : String(error)}`
+          );
+        }
 
         await handleCookieConsentBanner(
           page,

--- a/packages/backend/src/db.ts
+++ b/packages/backend/src/db.ts
@@ -44,6 +44,7 @@ sqlite.exec(`
     interactive_elements TEXT NOT NULL DEFAULT '[]',
     global_styles TEXT,
     annotated_screenshot_path TEXT,
+    viewport_width INTEGER,
     last_crawled_at INTEGER,
     last_crawl_job_id TEXT,
     created_at INTEGER NOT NULL,
@@ -231,6 +232,7 @@ ensureColumn("elements", "crop_error", "crop_error TEXT");
 ensureColumn("elements", "is_global_chrome", "is_global_chrome INTEGER DEFAULT 0");
 ensureColumn("pages", "annotated_screenshot_path", "annotated_screenshot_path TEXT");
 ensureColumn("pages", "last_crawl_run_id", "last_crawl_run_id INTEGER");
+ensureColumn("pages", "viewport_width", "viewport_width INTEGER");
 ensureColumn("crawl_runs", "discovery_run_id", "discovery_run_id INTEGER");
 ensureColumn("crawl_runs", "approved_urls_json", "approved_urls_json TEXT");
 ensureColumn("discovery_runs", "warnings_json", "warnings_json TEXT NOT NULL DEFAULT '[]'");

--- a/packages/backend/src/schema.ts
+++ b/packages/backend/src/schema.ts
@@ -28,6 +28,10 @@ export const pages = sqliteTable("pages", {
   interactiveElements: text("interactive_elements").notNull().default("[]"),
   globalStyles: text("global_styles"),
   annotatedScreenshotPath: text("annotated_screenshot_path"),
+  /** CSS viewport width at capture time. Distinct from the raw image pixel
+   * width, which is viewport × DPR. The plugin uses this to scale element
+   * bboxes correctly when DPR > 1. */
+  viewportWidth: integer("viewport_width"),
   lastCrawledAt: integer("last_crawled_at", { mode: "timestamp_ms" }),
   lastCrawlJobId: text("last_crawl_job_id"),
   lastCrawlRunId: integer("last_crawl_run_id"),

--- a/packages/backend/src/services/capture/__fixtures__/harness.test.ts
+++ b/packages/backend/src/services/capture/__fixtures__/harness.test.ts
@@ -1,0 +1,35 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { chromium, type Browser } from "playwright";
+import { startFixtureServer, type FixtureServer } from "./server.js";
+
+describe("capture fixture harness", () => {
+  let server: FixtureServer;
+  let browser: Browser;
+
+  beforeAll(async () => {
+    server = await startFixtureServer();
+    browser = await chromium.launch();
+  }, 30_000);
+
+  afterAll(async () => {
+    await browser?.close();
+    await server?.close();
+  });
+
+  it("serves a fixture page that Playwright can render", async () => {
+    const page = await browser.newPage();
+    await page.goto(`${server.baseUrl}/smoke.html`);
+    const text = await page.locator('[data-testid="hello"]').textContent();
+    expect(text).toBe("hello from fixture");
+    await page.close();
+  });
+
+  it("applies the ?delay query param before responding", async () => {
+    const page = await browser.newPage();
+    const start = Date.now();
+    await page.goto(`${server.baseUrl}/smoke.html?delay=200`);
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeGreaterThanOrEqual(180);
+    await page.close();
+  });
+});

--- a/packages/backend/src/services/capture/__fixtures__/pages/combined-capture.html
+++ b/packages/backend/src/services/capture/__fixtures__/pages/combined-capture.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Combined capture fixture</title>
+    <style>
+      body { margin: 0; font-family: "FixtureFont", sans-serif; }
+
+      /* Slow web font — exercises the fonts signal. */
+      @font-face {
+        font-family: "FixtureFont";
+        src: url("/test.font?delay=300") format("woff2");
+        font-display: block;
+      }
+
+      /* Running CSS animation — exercises the animations signal. */
+      @keyframes spin {
+        from { transform: rotate(0deg); }
+        to { transform: rotate(360deg); }
+      }
+      .spinner {
+        width: 40px;
+        height: 40px;
+        background: red;
+        animation: spin 10s linear infinite;
+      }
+
+      /* Sticky banners. The orchestrator filters by `.sticky`/`.fixed`
+         class names and inline position:sticky/fixed styles, so we use
+         those literal class names to match the existing selector. */
+      .sticky {
+        position: sticky;
+        top: 0;
+        padding: 8px;
+        background: yellow;
+      }
+
+      .row {
+        height: 600px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="sticky" data-testid="banner-1">sticky 1</div>
+    <div class="sticky" data-testid="banner-2">sticky 2</div>
+
+    <div class="spinner" data-testid="spinner"></div>
+
+    <!-- Lazy images further down the page — exercises the lazy-trigger
+         + image-decode signals. -->
+    <div class="row"><img loading="lazy" src="/test.png?size=120x120&n=0" /></div>
+    <div class="row"><img loading="lazy" src="/test.png?size=120x120&n=1" /></div>
+    <div class="row"><img loading="lazy" src="/test.png?size=120x120&n=2" /></div>
+    <div class="row"><img loading="lazy" src="/test.png?size=120x120&n=3" /></div>
+
+    <span style="font-family: FixtureFont">webfont sample</span>
+  </body>
+</html>

--- a/packages/backend/src/services/capture/__fixtures__/pages/delayed-image.html
+++ b/packages/backend/src/services/capture/__fixtures__/pages/delayed-image.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Delayed image fixture</title>
+  </head>
+  <body>
+    <img id="hero" src="/test.png?delay=500" alt="" />
+  </body>
+</html>

--- a/packages/backend/src/services/capture/__fixtures__/pages/infinite-scroll.html
+++ b/packages/backend/src/services/capture/__fixtures__/pages/infinite-scroll.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Infinite scroll fixture</title>
+    <style>
+      body { margin: 0; }
+      .item { height: 400px; border-bottom: 1px solid #ccc; padding: 24px; }
+    </style>
+  </head>
+  <body>
+    <div id="feed"></div>
+    <script>
+      const feed = document.getElementById("feed");
+      let counter = 0;
+      function appendBatch(n) {
+        for (let i = 0; i < n; i++) {
+          const div = document.createElement("div");
+          div.className = "item";
+          div.textContent = `item ${counter++}`;
+          feed.appendChild(div);
+        }
+      }
+      appendBatch(5);
+      // Whenever the bottom comes into view, append more items forever.
+      const sentinel = document.createElement("div");
+      sentinel.id = "sentinel";
+      sentinel.style.height = "1px";
+      feed.parentElement.appendChild(sentinel);
+      new IntersectionObserver(
+        (entries) => {
+          for (const e of entries) {
+            if (e.isIntersecting) appendBatch(5);
+          }
+        },
+        { rootMargin: "200px" }
+      ).observe(sentinel);
+    </script>
+  </body>
+</html>

--- a/packages/backend/src/services/capture/__fixtures__/pages/late-inserted-image.html
+++ b/packages/backend/src/services/capture/__fixtures__/pages/late-inserted-image.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Late-inserted image fixture</title>
+  </head>
+  <body>
+    <div id="container"></div>
+    <script>
+      // Mimics React hydration: an empty wrapper at page-load time gets a
+      // child <img> inserted later. Listeners bound to elements that exist
+      // when the detector starts won't fire for this new node.
+      setTimeout(() => {
+        const img = document.createElement("img");
+        img.id = "hydrated";
+        img.src = "/test.png?delay=200&size=300x200";
+        document.getElementById("container").appendChild(img);
+      }, 400);
+    </script>
+  </body>
+</html>

--- a/packages/backend/src/services/capture/__fixtures__/pages/late-set-src.html
+++ b/packages/backend/src/services/capture/__fixtures__/pages/late-set-src.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Late-set src fixture</title>
+  </head>
+  <body>
+    <!-- This mimics atera.com's customer-logo pattern: <img src=""> with a
+         meaningful alt, and a script that swaps in the real src after page
+         "hydration". -->
+    <img id="hero" src="" alt="Logo=Acme, Color=White" />
+    <script>
+      setTimeout(() => {
+        const img = document.getElementById("hero");
+        img.src = "/test.png?delay=200&size=200x100";
+      }, 350);
+    </script>
+  </body>
+</html>

--- a/packages/backend/src/services/capture/__fixtures__/pages/lazy-images.html
+++ b/packages/backend/src/services/capture/__fixtures__/pages/lazy-images.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Lazy image fixture</title>
+    <style>
+      body { margin: 0; }
+      .row { height: 600px; display: flex; align-items: center; justify-content: center; }
+    </style>
+  </head>
+  <body>
+    <div class="row"><img loading="lazy" src="/test.png?size=200x200&n=0" /></div>
+    <div class="row"><img loading="lazy" src="/test.png?size=200x200&n=1" /></div>
+    <div class="row"><img loading="lazy" src="/test.png?size=200x200&n=2" /></div>
+    <div class="row"><img loading="lazy" src="/test.png?size=200x200&n=3" /></div>
+    <div class="row"><img loading="lazy" src="/test.png?size=200x200&n=4" /></div>
+    <div class="row"><img loading="lazy" src="/test.png?size=200x200&n=5" /></div>
+    <div class="row"><img loading="lazy" src="/test.png?size=200x200&n=6" /></div>
+    <div class="row"><img loading="lazy" src="/test.png?size=200x200&n=7" /></div>
+    <div class="row"><img loading="lazy" src="/test.png?size=200x200&n=8" /></div>
+    <div class="row"><img loading="lazy" src="/test.png?size=200x200&n=9" /></div>
+  </body>
+</html>

--- a/packages/backend/src/services/capture/__fixtures__/pages/never-loading-image.html
+++ b/packages/backend/src/services/capture/__fixtures__/pages/never-loading-image.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Never-loading image fixture</title>
+  </head>
+  <body>
+    <h1>page with a hung image</h1>
+    <img id="hero" src="/__never__" alt="" />
+  </body>
+</html>

--- a/packages/backend/src/services/capture/__fixtures__/pages/noisy-dom.html
+++ b/packages/backend/src/services/capture/__fixtures__/pages/noisy-dom.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Noisy DOM fixture</title>
+  </head>
+  <body>
+    <h1>This page has constant DOM churn but no pending images</h1>
+    <div id="ticker"></div>
+    <script>
+      // Simulates analytics/idle-loop DOM activity that should NOT block the
+      // image-decode signal — the mutations don't touch any <img>.
+      const ticker = document.getElementById("ticker");
+      let i = 0;
+      setInterval(() => {
+        ticker.innerHTML = "<span>tick " + i++ + "</span>";
+      }, 50);
+    </script>
+  </body>
+</html>

--- a/packages/backend/src/services/capture/__fixtures__/pages/request-settling.html
+++ b/packages/backend/src/services/capture/__fixtures__/pages/request-settling.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Request settling fixture</title>
+  </head>
+  <body>
+    <div data-testid="ready">request settling</div>
+    <script>
+      (async () => {
+        // Burst of three short responses ~200ms apart. After the last one,
+        // there is no more traffic — the request-settling signal should
+        // resolve a configurable quiet window later.
+        for (let i = 0; i < 3; i++) {
+          await fetch(`/test.png?delay=100&size=8x8&n=${i}`);
+        }
+        // Long-polling request that never responds — the detector must NOT
+        // block on this, because in-flight requests do not affect the
+        // request-settling quiet window.
+        fetch("/__never__").catch(() => {});
+      })();
+    </script>
+  </body>
+</html>

--- a/packages/backend/src/services/capture/__fixtures__/pages/running-animation.html
+++ b/packages/backend/src/services/capture/__fixtures__/pages/running-animation.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Running animation fixture</title>
+    <style>
+      @keyframes spin {
+        from { transform: rotate(0deg); }
+        to { transform: rotate(360deg); }
+      }
+      .spinner {
+        width: 40px;
+        height: 40px;
+        background: red;
+        animation: spin 10s linear infinite;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="spinner" data-testid="spinner"></div>
+  </body>
+</html>

--- a/packages/backend/src/services/capture/__fixtures__/pages/slow-background.html
+++ b/packages/backend/src/services/capture/__fixtures__/pages/slow-background.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Slow CSS background fixture</title>
+    <style>
+      .hero {
+        width: 320px;
+        height: 200px;
+        background-image: url("/test.png?delay=500&size=320x200");
+        background-size: cover;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="hero" data-testid="hero"></div>
+  </body>
+</html>

--- a/packages/backend/src/services/capture/__fixtures__/pages/slow-font.html
+++ b/packages/backend/src/services/capture/__fixtures__/pages/slow-font.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Slow font fixture</title>
+    <style>
+      @font-face {
+        font-family: "FixtureFont";
+        src: url("/test.font?delay=400") format("woff2");
+        font-display: block;
+      }
+      .needs-font {
+        font-family: "FixtureFont", sans-serif;
+      }
+    </style>
+  </head>
+  <body>
+    <span class="needs-font" data-testid="text">webfont sample</span>
+  </body>
+</html>

--- a/packages/backend/src/services/capture/__fixtures__/pages/smoke.html
+++ b/packages/backend/src/services/capture/__fixtures__/pages/smoke.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Smoke fixture</title>
+  </head>
+  <body>
+    <h1 data-testid="hello">hello from fixture</h1>
+  </body>
+</html>

--- a/packages/backend/src/services/capture/__fixtures__/pages/video-poster.html
+++ b/packages/backend/src/services/capture/__fixtures__/pages/video-poster.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Video poster fixture</title>
+  </head>
+  <body>
+    <video
+      data-testid="hero-video"
+      width="320"
+      height="200"
+      preload="none"
+      poster="/test.png?delay=400&size=320x200"
+    ></video>
+  </body>
+</html>

--- a/packages/backend/src/services/capture/__fixtures__/server.ts
+++ b/packages/backend/src/services/capture/__fixtures__/server.ts
@@ -1,0 +1,143 @@
+import { createServer, IncomingMessage, ServerResponse } from "node:http";
+import { readFile, stat } from "node:fs/promises";
+import { extname, join, normalize, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import sharp from "sharp";
+
+const PAGES_DIR = resolve(fileURLToPath(new URL("./pages", import.meta.url)));
+
+const CONTENT_TYPES: Record<string, string> = {
+  ".html": "text/html; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".js": "application/javascript; charset=utf-8",
+  ".woff2": "font/woff2",
+  ".woff": "font/woff",
+  ".ttf": "font/ttf",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".svg": "image/svg+xml",
+  ".webp": "image/webp",
+  ".mp4": "video/mp4",
+};
+
+export interface FixtureServer {
+  baseUrl: string;
+  close: () => Promise<void>;
+}
+
+export async function startFixtureServer(): Promise<FixtureServer> {
+  const server = createServer(async (req, res) => {
+    try {
+      await handleRequest(req, res);
+    } catch (error) {
+      res.statusCode = 500;
+      res.end(error instanceof Error ? error.message : String(error));
+    }
+  });
+
+  await new Promise<void>((resolveListen) => server.listen(0, "127.0.0.1", resolveListen));
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Fixture server failed to bind to a port");
+  }
+
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+
+  return {
+    baseUrl,
+    close: () =>
+      new Promise<void>((resolveClose, rejectClose) =>
+        server.close((err) => (err ? rejectClose(err) : resolveClose()))
+      ),
+  };
+}
+
+async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  const url = new URL(req.url ?? "/", "http://localhost");
+  const delayMs = parsePositiveInt(url.searchParams.get("delay"));
+  if (delayMs > 0) {
+    await sleep(delayMs);
+  }
+
+  // Long-polling fixture endpoint: never responds within the test budget.
+  if (url.pathname === "/__never__") {
+    return;
+  }
+
+  // Synthetic font endpoint — bytes are not a real font, but the browser will
+  // still issue the request, wait for the delay, and resolve document.fonts.ready
+  // after the load attempt completes (success or error). Sufficient for testing
+  // that the detector waited for the network round-trip.
+  if (url.pathname === "/test.font") {
+    res.statusCode = 200;
+    res.setHeader("Content-Type", "font/woff2");
+    res.setHeader("Cache-Control", "no-store");
+    res.end(Buffer.from([0x77, 0x4f, 0x46, 0x32])); // "wOF2" magic, invalid body
+    return;
+  }
+
+  // Synthetic PNG for image-decode fixtures; size is configurable via ?size=NxN.
+  if (url.pathname === "/test.png") {
+    const size = parseSize(url.searchParams.get("size")) ?? { width: 64, height: 64 };
+    const buf = await sharp({
+      create: {
+        width: size.width,
+        height: size.height,
+        channels: 4,
+        background: { r: 255, g: 64, b: 128, alpha: 1 },
+      },
+    })
+      .png()
+      .toBuffer();
+    res.statusCode = 200;
+    res.setHeader("Content-Type", "image/png");
+    res.setHeader("Cache-Control", "no-store");
+    res.end(buf);
+    return;
+  }
+
+  const requested = url.pathname === "/" ? "/index.html" : url.pathname;
+  const safePath = normalize(requested).replace(/^([./\\])+/, "");
+  const filePath = join(PAGES_DIR, safePath);
+
+  if (!filePath.startsWith(PAGES_DIR)) {
+    res.statusCode = 403;
+    res.end("Forbidden");
+    return;
+  }
+
+  try {
+    const fileStat = await stat(filePath);
+    if (!fileStat.isFile()) {
+      res.statusCode = 404;
+      res.end("Not found");
+      return;
+    }
+    const body = await readFile(filePath);
+    res.statusCode = 200;
+    res.setHeader("Content-Type", CONTENT_TYPES[extname(filePath)] ?? "application/octet-stream");
+    res.setHeader("Cache-Control", "no-store");
+    res.end(body);
+  } catch {
+    res.statusCode = 404;
+    res.end("Not found");
+  }
+}
+
+function parseSize(raw: string | null): { width: number; height: number } | null {
+  if (!raw) return null;
+  const match = /^(\d+)x(\d+)$/.exec(raw);
+  if (!match || !match[1] || !match[2]) return null;
+  return { width: Number.parseInt(match[1], 10), height: Number.parseInt(match[2], 10) };
+}
+
+function parsePositiveInt(raw: string | null): number {
+  if (!raw) return 0;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : 0;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolveSleep) => setTimeout(resolveSleep, ms));
+}

--- a/packages/backend/src/services/capture/highFidelityCapture.test.ts
+++ b/packages/backend/src/services/capture/highFidelityCapture.test.ts
@@ -1,0 +1,81 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { chromium, type Browser } from "playwright";
+import sharp from "sharp";
+import { startFixtureServer, type FixtureServer } from "./__fixtures__/server.js";
+import { captureHighFidelity } from "./highFidelityCapture.js";
+
+describe("HighFidelityCapture", () => {
+  let server: FixtureServer;
+  let browser: Browser;
+
+  beforeAll(async () => {
+    server = await startFixtureServer();
+    browser = await chromium.launch();
+  }, 30_000);
+
+  afterAll(async () => {
+    await browser?.close();
+    await server?.close();
+  });
+
+  it("captures a page combining lazy images + web font + animation + sticky banner", async () => {
+    // DPR 2 so we can verify the orchestrator's raster is the CSS viewport
+    // × DPR, the same guarantee the production capture relies on.
+    const context = await browser.newContext({
+      viewport: { width: 800, height: 600 },
+      deviceScaleFactor: 2,
+    });
+    const page = await context.newPage();
+    await page.goto(`${server.baseUrl}/combined-capture.html`, { waitUntil: "commit" });
+
+    const dismissBannersCalls: number[] = [];
+    const dismissBanners = async () => {
+      dismissBannersCalls.push(Date.now());
+    };
+
+    const result = await captureHighFidelity(page, {
+      dismissBanners,
+      readiness: { domQuietWindowMs: 400 },
+    });
+
+    // 1. Buffer is a real PNG with DPR 2 dimensions for our 800-wide viewport.
+    expect(Buffer.isBuffer(result.buffer)).toBe(true);
+    const meta = await sharp(result.buffer).metadata();
+    expect(meta.width).toBe(1600); // 800 CSS × DPR 2
+    expect(meta.height).toBeGreaterThan(600); // full-page, includes lazy rows
+    expect(result.width).toBe(meta.width);
+    expect(result.height).toBe(meta.height);
+
+    // 2. Readiness report has all signals fired (no timeouts on a healthy page).
+    expect(result.readinessReport.images).toBe("fired");
+    expect(result.readinessReport.fonts).toBe("fired");
+    expect(result.readinessReport.animations).toBe("fired");
+
+    // 3. dismissBanners was invoked at least once.
+    expect(dismissBannersCalls.length).toBeGreaterThan(0);
+
+    // 4. After capture, lazy images are loaded (proof the trigger ran).
+    const loadedCount = await page.evaluate(
+      () => Array.from(document.images).filter((i) => i.complete && i.naturalWidth > 0).length
+    );
+    expect(loadedCount).toBe(4);
+
+    // 5. Sticky banner: only the topmost should remain visible.
+    const visibility = await page.evaluate(() => {
+      const b1 = document.querySelector('[data-testid="banner-1"]') as HTMLElement;
+      const b2 = document.querySelector('[data-testid="banner-2"]') as HTMLElement;
+      return {
+        b1Display: b1?.style.display ?? "(unset)",
+        b2Display: b2?.style.display ?? "(unset)",
+      };
+    });
+    expect(visibility.b1Display).not.toBe("none"); // topmost preserved
+    expect(visibility.b2Display).toBe("none"); // hidden by orchestrator
+
+    // 6. Page ends scrolled to top so the screenshot starts at y=0.
+    const scrollY = await page.evaluate(() => window.scrollY);
+    expect(scrollY).toBe(0);
+
+    await context.close();
+  }, 30_000);
+});

--- a/packages/backend/src/services/capture/highFidelityCapture.ts
+++ b/packages/backend/src/services/capture/highFidelityCapture.ts
@@ -1,0 +1,105 @@
+import type { Page } from "playwright";
+import {
+  triggerLazyContent,
+  type TriggerLazyContentOptions,
+} from "./lazyContentTrigger.js";
+import {
+  waitUntilStable,
+  type ReadinessReport,
+  type WaitUntilStableOptions,
+} from "./pageReadyDetector.js";
+
+export interface CaptureOptions {
+  /** Optional callback invoked at three points where cookie banners are
+   * most likely to re-appear: before lazy-trigger, after lazy-trigger,
+   * and after scroll-to-top. The orchestrator does not own cookie banner
+   * logic — extracting that is out of scope. */
+  dismissBanners?: () => Promise<void>;
+  readiness?: WaitUntilStableOptions;
+  lazy?: TriggerLazyContentOptions;
+}
+
+export interface CaptureResult {
+  buffer: Buffer;
+  width: number;
+  height: number;
+  readinessReport: ReadinessReport;
+}
+
+export async function captureHighFidelity(
+  page: Page,
+  opts: CaptureOptions = {}
+): Promise<CaptureResult> {
+  const dismiss = opts.dismissBanners ?? (async () => undefined);
+
+  // 1. Pre-pass: dismiss banners that were visible at first paint.
+  await dismiss();
+
+  // 2. Hide sticky / fixed elements except the topmost — otherwise they
+  //    repeat down a long-page screenshot. Behaviour preserved from the
+  //    legacy inline flow in crawler.ts.
+  await hideRedundantStickyElements(page);
+
+  // 3. Trigger lazy-loaded content.
+  await triggerLazyContent(page, opts.lazy);
+
+  // 4. Banners may have re-appeared once lazy content rendered.
+  await dismiss();
+
+  // 5. Scroll to top so the screenshot starts at y=0. LazyContentTrigger
+  //    already returns scrolled to top, but a banner-dismiss handler may
+  //    have scrolled the page, so we re-anchor here.
+  await scrollToTop(page);
+
+  // 6. One last banner pass after the final scroll position is set.
+  await dismiss();
+
+  // 7. Readiness wait. With lazy content already loaded and animations
+  //    paused, this is now a final-frame guarantee rather than an
+  //    open-ended timeout.
+  const readinessReport = await waitUntilStable(page, opts.readiness);
+
+  // 8. Take the screenshot.
+  const buffer = await page.screenshot({ fullPage: true, type: "png" });
+
+  const dims = await pngDimensions(buffer);
+
+  return { buffer, width: dims.width, height: dims.height, readinessReport };
+}
+
+async function hideRedundantStickyElements(page: Page): Promise<void> {
+  await page
+    .evaluate(() => {
+      const stickyElements = document.querySelectorAll(
+        '[style*="position: fixed"], [style*="position: sticky"], .sticky, .fixed'
+      );
+      stickyElements.forEach((el, index) => {
+        if (index > 0) (el as HTMLElement).style.display = "none";
+      });
+      document.documentElement.style.transform = "none";
+      document.body.style.transform = "none";
+    })
+    .catch(() => undefined);
+}
+
+async function scrollToTop(page: Page): Promise<void> {
+  await page
+    .evaluate(() => {
+      window.scrollTo({ top: 0, behavior: "instant" as ScrollBehavior });
+      document.documentElement.scrollTop = 0;
+      document.body.scrollTop = 0;
+      if (document.scrollingElement) document.scrollingElement.scrollTop = 0;
+    })
+    .catch(() => undefined);
+  // Tiny pause for layout to settle after scroll mutations — preserved
+  // from the legacy inline flow.
+  await page.waitForTimeout(300);
+}
+
+async function pngDimensions(buffer: Buffer): Promise<{ width: number; height: number }> {
+  // PNG dimensions live in the IHDR chunk at bytes 16..24 (big-endian uint32).
+  if (buffer.length < 24) return { width: 0, height: 0 };
+  const width = buffer.readUInt32BE(16);
+  const height = buffer.readUInt32BE(20);
+  return { width, height };
+}

--- a/packages/backend/src/services/capture/lazyContentTrigger.test.ts
+++ b/packages/backend/src/services/capture/lazyContentTrigger.test.ts
@@ -1,0 +1,74 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { chromium, type Browser } from "playwright";
+import { startFixtureServer, type FixtureServer } from "./__fixtures__/server.js";
+import { triggerLazyContent } from "./lazyContentTrigger.js";
+
+describe("LazyContentTrigger", () => {
+  let server: FixtureServer;
+  let browser: Browser;
+
+  beforeAll(async () => {
+    server = await startFixtureServer();
+    browser = await chromium.launch();
+  }, 30_000);
+
+  afterAll(async () => {
+    await browser?.close();
+    await server?.close();
+  });
+
+  it("terminates within its step budget on an infinite-scroll page", async () => {
+    const page = await browser.newPage({ viewport: { width: 800, height: 600 } });
+    await page.goto(`${server.baseUrl}/infinite-scroll.html`, { waitUntil: "load" });
+
+    const start = Date.now();
+    await triggerLazyContent(page, {
+      // Tight budget so the test runs fast — proves the trigger respects the
+      // cap rather than scrolling forever.
+      maxSteps: 5,
+      quietWindowMs: 100,
+      overallTimeoutMs: 5_000,
+    });
+    const elapsedMs = Date.now() - start;
+
+    expect(elapsedMs).toBeLessThan(4_000);
+
+    await page.close();
+  }, 15_000);
+
+  it("returns the page scrolled to the top so subsequent screenshots start at y=0", async () => {
+    const page = await browser.newPage({ viewport: { width: 800, height: 600 } });
+    await page.goto(`${server.baseUrl}/lazy-images.html`, { waitUntil: "load" });
+
+    await triggerLazyContent(page);
+
+    const scrollY = await page.evaluate(() => window.scrollY);
+    expect(scrollY).toBe(0);
+
+    await page.close();
+  }, 15_000);
+
+  it("scrolls the page so all lazy-loaded images end up loaded", async () => {
+    const page = await browser.newPage({ viewport: { width: 800, height: 600 } });
+    await page.goto(`${server.baseUrl}/lazy-images.html`, { waitUntil: "load" });
+
+    // Sanity: at least some lazy images should be unloaded before the trigger runs.
+    const beforeLoaded = await page.evaluate(
+      () => document.querySelectorAll("img").length === 0
+        ? 0
+        : Array.from(document.images).filter((img) => img.complete && img.naturalWidth > 0).length
+    );
+    const total = await page.evaluate(() => document.images.length);
+    expect(total).toBe(10);
+    expect(beforeLoaded).toBeLessThan(total);
+
+    await triggerLazyContent(page);
+
+    const afterLoaded = await page.evaluate(
+      () => Array.from(document.images).filter((img) => img.complete && img.naturalWidth > 0).length
+    );
+    expect(afterLoaded).toBe(total);
+
+    await page.close();
+  }, 30_000);
+});

--- a/packages/backend/src/services/capture/lazyContentTrigger.ts
+++ b/packages/backend/src/services/capture/lazyContentTrigger.ts
@@ -1,0 +1,75 @@
+import type { Page } from "playwright";
+
+export interface TriggerLazyContentOptions {
+  /** Quiet window between scroll steps — wait this long with no new network
+   * responses before advancing to the next viewport. */
+  quietWindowMs?: number;
+  /** Hard cap on total steps so infinite-scroll pages cannot loop forever. */
+  maxSteps?: number;
+  /** Overall ceiling regardless of step count. */
+  overallTimeoutMs?: number;
+}
+
+const DEFAULT_QUIET_WINDOW_MS = 400;
+const DEFAULT_MAX_STEPS = 40;
+const DEFAULT_OVERALL_TIMEOUT_MS = 30_000;
+
+export async function triggerLazyContent(
+  page: Page,
+  opts: TriggerLazyContentOptions = {}
+): Promise<void> {
+  const quietWindowMs = opts.quietWindowMs ?? DEFAULT_QUIET_WINDOW_MS;
+  const maxSteps = opts.maxSteps ?? DEFAULT_MAX_STEPS;
+  const overallTimeoutMs = opts.overallTimeoutMs ?? DEFAULT_OVERALL_TIMEOUT_MS;
+
+  const deadline = Date.now() + overallTimeoutMs;
+  let lastResponseAt = Date.now();
+  const onResponse = () => {
+    lastResponseAt = Date.now();
+  };
+  page.on("response", onResponse);
+
+  try {
+    for (let step = 0; step < maxSteps; step++) {
+      if (Date.now() >= deadline) break;
+
+      const { reachedBottom } = await page.evaluate(() => {
+        const viewportHeight = window.innerHeight;
+        const before = window.scrollY;
+        window.scrollBy(0, viewportHeight);
+        const after = window.scrollY;
+        const maxScroll =
+          (document.documentElement.scrollHeight || document.body.scrollHeight) -
+          window.innerHeight;
+        return { reachedBottom: after === before || after >= maxScroll };
+      });
+
+      await waitForQuiet(quietWindowMs, () => lastResponseAt, deadline);
+
+      if (reachedBottom) break;
+    }
+  } finally {
+    page.off("response", onResponse);
+  }
+
+  // Return scrolled to top — leaves the page in a known state for the
+  // subsequent screenshot.
+  await page.evaluate(() => {
+    window.scrollTo(0, 0);
+    document.documentElement.scrollTop = 0;
+    document.body.scrollTop = 0;
+  });
+}
+
+async function waitForQuiet(
+  quietWindowMs: number,
+  getLastResponseAt: () => number,
+  deadline: number
+): Promise<void> {
+  while (Date.now() < deadline) {
+    const sinceLast = Date.now() - getLastResponseAt();
+    if (sinceLast >= quietWindowMs) return;
+    const remaining = quietWindowMs - sinceLast;
+    await new Promise((r) => setTimeout(r, Math.max(remaining, 25)));
+  }
+}

--- a/packages/backend/src/services/capture/pageReadyDetector.test.ts
+++ b/packages/backend/src/services/capture/pageReadyDetector.test.ts
@@ -159,6 +159,23 @@ describe("PageReadyDetector", () => {
     await page.close();
   }, 15_000);
 
+  it("returns quickly when the page has constant DOM noise but no pending images", async () => {
+    const page = await browser.newPage();
+    await page.goto(`${server.baseUrl}/noisy-dom.html`, { waitUntil: "commit" });
+
+    const start = Date.now();
+    const report = await waitUntilStable(page, { domQuietWindowMs: 400 });
+    const elapsedMs = Date.now() - start;
+
+    // Constant unrelated DOM mutations must not keep the image-decode signal
+    // open. Anything well below the 15s per-signal timeout proves the quiet
+    // window is converging.
+    expect(elapsedMs).toBeLessThan(3_000);
+    expect(report.images).toBe("fired");
+
+    await page.close();
+  }, 15_000);
+
   it("waits for images whose src is populated late by JS (DOM mutations)", async () => {
     const page = await browser.newPage();
     await page.goto(`${server.baseUrl}/late-set-src.html`, { waitUntil: "commit" });

--- a/packages/backend/src/services/capture/pageReadyDetector.test.ts
+++ b/packages/backend/src/services/capture/pageReadyDetector.test.ts
@@ -139,6 +139,43 @@ describe("PageReadyDetector", () => {
     await page.close();
   }, 15_000);
 
+  it("waits for images inserted into the DOM after page load (React-style hydration)", async () => {
+    const page = await browser.newPage();
+    await page.goto(`${server.baseUrl}/late-inserted-image.html`, { waitUntil: "commit" });
+
+    // domQuietWindowMs is the maximum window the detector waits with no DOM
+    // mutations before declaring the page settled.
+    await waitUntilStable(page, { domQuietWindowMs: 500 });
+
+    const imgState = await page.evaluate(() => {
+      const img = document.getElementById("hydrated") as HTMLImageElement | null;
+      return img ? { complete: img.complete, naturalWidth: img.naturalWidth } : null;
+    });
+
+    expect(imgState).not.toBeNull();
+    expect(imgState!.complete).toBe(true);
+    expect(imgState!.naturalWidth).toBeGreaterThan(0);
+
+    await page.close();
+  }, 15_000);
+
+  it("waits for images whose src is populated late by JS (DOM mutations)", async () => {
+    const page = await browser.newPage();
+    await page.goto(`${server.baseUrl}/late-set-src.html`, { waitUntil: "commit" });
+
+    await waitUntilStable(page, { domQuietWindowMs: 500 });
+
+    const imgState = await page.evaluate(() => {
+      const img = document.getElementById("hero") as HTMLImageElement;
+      return { complete: img.complete, naturalWidth: img.naturalWidth };
+    });
+
+    expect(imgState.complete).toBe(true);
+    expect(imgState.naturalWidth).toBeGreaterThan(0);
+
+    await page.close();
+  }, 15_000);
+
   it("waits for delayed <img> elements to load and decode before resolving", async () => {
     const page = await browser.newPage();
     // The fixture image is delayed by the server (?delay=500). If the detector

--- a/packages/backend/src/services/capture/pageReadyDetector.test.ts
+++ b/packages/backend/src/services/capture/pageReadyDetector.test.ts
@@ -1,0 +1,165 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { chromium, type Browser } from "playwright";
+import { startFixtureServer, type FixtureServer } from "./__fixtures__/server.js";
+import { waitUntilStable } from "./pageReadyDetector.js";
+
+describe("PageReadyDetector", () => {
+  let server: FixtureServer;
+  let browser: Browser;
+
+  beforeAll(async () => {
+    server = await startFixtureServer();
+    browser = await chromium.launch();
+  }, 30_000);
+
+  afterAll(async () => {
+    await browser?.close();
+    await server?.close();
+  });
+
+  it("waits for document.fonts.ready before resolving", async () => {
+    const page = await browser.newPage();
+    await page.goto(`${server.baseUrl}/slow-font.html`, { waitUntil: "commit" });
+
+    const start = Date.now();
+    const report = await waitUntilStable(page);
+    const elapsedMs = Date.now() - start;
+
+    // Font load is delayed 400ms by the fixture server; if the detector
+    // resolved without waiting on document.fonts.ready, elapsedMs would be
+    // far below that floor.
+    expect(elapsedMs).toBeGreaterThanOrEqual(350);
+
+    const fontsStatus = await page.evaluate(() => document.fonts.status);
+    expect(fontsStatus).toBe("loaded");
+    expect(report.fonts).toBe("fired");
+
+    await page.close();
+  }, 15_000);
+
+  it("waits for delayed CSS background-image to load before resolving", async () => {
+    const page = await browser.newPage();
+    await page.goto(`${server.baseUrl}/slow-background.html`, { waitUntil: "commit" });
+
+    const start = Date.now();
+    const report = await waitUntilStable(page);
+    const elapsedMs = Date.now() - start;
+
+    expect(elapsedMs).toBeGreaterThanOrEqual(400);
+    expect(report.backgroundImages).toBe("fired");
+
+    await page.close();
+  }, 15_000);
+
+  it("settles running CSS animations so the page is visually stable", async () => {
+    const page = await browser.newPage();
+    await page.goto(`${server.baseUrl}/running-animation.html`, { waitUntil: "commit" });
+
+    // Sanity: before the detector runs, there should be at least one running animation.
+    const beforeRunning = await page.evaluate(
+      () =>
+        document.getAnimations().filter((a) => a.playState === "running").length
+    );
+    expect(beforeRunning).toBeGreaterThan(0);
+
+    const report = await waitUntilStable(page);
+
+    const afterRunning = await page.evaluate(
+      () =>
+        document.getAnimations().filter((a) => a.playState === "running").length
+    );
+    expect(afterRunning).toBe(0);
+    expect(report.animations).toBe("fired");
+
+    await page.close();
+  }, 15_000);
+
+  it("waits for delayed <video> poster images before resolving", async () => {
+    const page = await browser.newPage();
+    await page.goto(`${server.baseUrl}/video-poster.html`, { waitUntil: "commit" });
+
+    const start = Date.now();
+    const report = await waitUntilStable(page);
+    const elapsedMs = Date.now() - start;
+
+    expect(elapsedMs).toBeGreaterThanOrEqual(350);
+    expect(report.videos).toBe("fired");
+
+    await page.close();
+  }, 15_000);
+
+  it("resolves request-settling N ms after the last response, ignoring long-polling requests", async () => {
+    const page = await browser.newPage();
+    await page.goto(`${server.baseUrl}/request-settling.html`, { waitUntil: "commit" });
+
+    const start = Date.now();
+    const report = await waitUntilStable(page, {
+      // Shorter quiet window so the test runs fast. Other signals are no-ops
+      // for this fixture, so the request-settling timing dominates.
+      requestSettleQuietWindowMs: 400,
+      // Bound the overall ceiling so a regression that blocks on /__never__
+      // makes the test obviously hang against the ceiling instead of timing
+      // out at vitest's outer timer.
+      overallTimeoutMs: 5_000,
+    });
+    const elapsedMs = Date.now() - start;
+
+    // Three 100ms-delayed responses ≈ 600ms+ to fire the burst, then a 400ms
+    // quiet window. So a healthy run lands roughly 1000–1500ms.
+    expect(elapsedMs).toBeGreaterThanOrEqual(700);
+    expect(elapsedMs).toBeLessThan(3_000);
+    expect(report.requests).toBe("fired");
+
+    await page.close();
+  }, 15_000);
+
+  it("bounds total wait by overallTimeoutMs and returns a partial readiness report instead of throwing", async () => {
+    const page = await browser.newPage();
+    await page.goto(`${server.baseUrl}/never-loading-image.html`, {
+      waitUntil: "commit",
+    });
+
+    const start = Date.now();
+    const report = await waitUntilStable(page, {
+      overallTimeoutMs: 800,
+      // Short request quiet window so that signal completes quickly and
+      // doesn't dominate the elapsed time.
+      requestSettleQuietWindowMs: 300,
+    });
+    const elapsedMs = Date.now() - start;
+
+    expect(elapsedMs).toBeLessThan(1_500);
+    // Image never loads → that signal should report timeout.
+    expect(report.images).toBe("timeout");
+    // Other signals should still fire — the detector reports per-signal
+    // outcomes, not a single pass/fail.
+    expect(report.fonts).toBe("fired");
+    expect(report.animations).toBe("fired");
+
+    await page.close();
+  }, 15_000);
+
+  it("waits for delayed <img> elements to load and decode before resolving", async () => {
+    const page = await browser.newPage();
+    // The fixture image is delayed by the server (?delay=500). If the detector
+    // returns before the image has loaded, the assertion below will fail —
+    // proving the detector actually waited.
+    await page.goto(`${server.baseUrl}/delayed-image.html`, { waitUntil: "commit" });
+
+    const report = await waitUntilStable(page);
+
+    const imageState = await page.evaluate(() => {
+      const img = document.getElementById("hero") as HTMLImageElement | null;
+      return img
+        ? { complete: img.complete, naturalWidth: img.naturalWidth }
+        : null;
+    });
+
+    expect(imageState).not.toBeNull();
+    expect(imageState!.complete).toBe(true);
+    expect(imageState!.naturalWidth).toBeGreaterThan(0);
+    expect(report.images).toBe("fired");
+
+    await page.close();
+  }, 15_000);
+});

--- a/packages/backend/src/services/capture/pageReadyDetector.ts
+++ b/packages/backend/src/services/capture/pageReadyDetector.ts
@@ -20,6 +20,10 @@ export interface WaitUntilStableOptions {
   requestsTimeoutMs?: number;
   /** Quiet window for request-settling — resolves N ms after last response. */
   requestSettleQuietWindowMs?: number;
+  /** Quiet window for DOM stability — the image-decode signal waits for the
+   * DOM to be free of mutations for this long before declaring images
+   * settled, so late-hydrated <img> elements get picked up. */
+  domQuietWindowMs?: number;
   /** Overall ceiling. Every per-signal timeout is clamped to this value, so
    * the whole call returns within roughly this budget even if a signal hangs. */
   overallTimeoutMs?: number;
@@ -28,6 +32,7 @@ export interface WaitUntilStableOptions {
 const DEFAULT_SIGNAL_TIMEOUT_MS = 15_000;
 const DEFAULT_OVERALL_TIMEOUT_MS = 60_000;
 const DEFAULT_REQUEST_QUIET_WINDOW_MS = 500;
+const DEFAULT_DOM_QUIET_WINDOW_MS = 500;
 
 export async function waitUntilStable(
   page: Page,
@@ -50,9 +55,11 @@ export async function waitUntilStable(
   );
   const requestQuietWindowMs =
     opts.requestSettleQuietWindowMs ?? DEFAULT_REQUEST_QUIET_WINDOW_MS;
+  const domQuietWindowMs =
+    opts.domQuietWindowMs ?? DEFAULT_DOM_QUIET_WINDOW_MS;
 
   const [images, fonts, backgroundImages, animations, videos, requests] = await Promise.all([
-    runSignal(() => waitForAllImages(page), imagesTimeoutMs),
+    runSignal(() => waitForAllImages(page, domQuietWindowMs), imagesTimeoutMs),
     runSignal(() => waitForFonts(page), fontsTimeoutMs),
     runSignal(() => waitForBackgroundImages(page), backgroundImagesTimeoutMs),
     runSignal(() => settleAnimations(page), animationsTimeoutMs),
@@ -219,26 +226,71 @@ async function waitForFonts(page: Page): Promise<void> {
   });
 }
 
-async function waitForAllImages(page: Page): Promise<void> {
-  await page.evaluate(async () => {
-    const imgs = Array.from(document.images);
-    await Promise.all(
-      imgs.map(async (img) => {
-        if (!(img.complete && img.naturalWidth > 0)) {
-          await new Promise<void>((resolveImg) => {
-            const settle = () => resolveImg();
-            img.addEventListener("load", settle, { once: true });
-            img.addEventListener("error", settle, { once: true });
-          });
+async function waitForAllImages(page: Page, domQuietWindowMs: number): Promise<void> {
+  await page.evaluate(async (quietWindowMs) => {
+    // Poll-and-observe loop so that late-inserted or late-src'd images are
+    // picked up. Pure addEventListener-based waiting binds to the elements
+    // present at start, which misses React-style reconciliation that
+    // replaces nodes wholesale.
+    let lastChangeAt = Date.now();
+    const bump = () => {
+      lastChangeAt = Date.now();
+    };
+    const observer = new MutationObserver(bump);
+    observer.observe(document.documentElement, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ["src", "srcset"],
+    });
+
+    const isPending = (img: HTMLImageElement): boolean => {
+      // An <img src=""> has complete=true but naturalWidth=0 because the
+      // browser never issued a request. We treat it as "not pending" — there
+      // is nothing concrete to wait for; the DOM-quiet window will catch it
+      // if JS later sets the src.
+      if (!img.getAttribute("src") && !img.getAttribute("srcset")) return false;
+      return !(img.complete && img.naturalWidth > 0);
+    };
+
+    try {
+      while (true) {
+        const pending = Array.from(document.images).filter(isPending);
+        if (pending.length > 0) {
+          await Promise.all(
+            pending.map(
+              (img) =>
+                new Promise<void>((settle) => {
+                  const done = () => settle();
+                  img.addEventListener("load", done, { once: true });
+                  img.addEventListener("error", done, { once: true });
+                })
+            )
+          );
+          continue; // re-check; new images may have appeared during the wait
         }
-        if (typeof img.decode === "function") {
-          try {
-            await img.decode();
-          } catch {
-            // decode rejects for broken images; treat as settled
+        if (Date.now() - lastChangeAt >= quietWindowMs) break;
+        await new Promise((tick) => setTimeout(tick, 50));
+      }
+
+      // Decode pass on every loaded image so the bitmap is in the raster
+      // before screenshot.
+      const loaded = Array.from(document.images).filter(
+        (img) => img.complete && img.naturalWidth > 0
+      );
+      await Promise.all(
+        loaded.map(async (img) => {
+          if (typeof img.decode === "function") {
+            try {
+              await img.decode();
+            } catch {
+              /* ignore decode errors */
+            }
           }
-        }
-      })
-    );
-  });
+        })
+      );
+    } finally {
+      observer.disconnect();
+    }
+  }, domQuietWindowMs);
 }

--- a/packages/backend/src/services/capture/pageReadyDetector.ts
+++ b/packages/backend/src/services/capture/pageReadyDetector.ts
@@ -232,11 +232,38 @@ async function waitForAllImages(page: Page, domQuietWindowMs: number): Promise<v
     // picked up. Pure addEventListener-based waiting binds to the elements
     // present at start, which misses React-style reconciliation that
     // replaces nodes wholesale.
+    //
+    // The observer only treats *image-relevant* mutations as activity — an
+    // <img> being added/removed, or its src/srcset attribute changing.
+    // Unrelated DOM churn (analytics tickers, framework idle work) does not
+    // reset the quiet window, otherwise pages with any background activity
+    // would never converge.
     let lastChangeAt = Date.now();
-    const bump = () => {
-      lastChangeAt = Date.now();
+    const involvesImage = (node: Node): boolean => {
+      if (node.nodeType !== 1 /* Node.ELEMENT_NODE */) return false;
+      const el = node as Element;
+      return el.tagName === "IMG" || !!el.querySelector?.("img");
     };
-    const observer = new MutationObserver(bump);
+    const observer = new MutationObserver((records) => {
+      for (const r of records) {
+        if (r.type === "attributes") {
+          // attributeFilter restricts us to src/srcset, so any hit here is
+          // an image mutation.
+          lastChangeAt = Date.now();
+          return;
+        }
+        if (r.type === "childList") {
+          for (const n of r.addedNodes) if (involvesImage(n)) {
+            lastChangeAt = Date.now();
+            return;
+          }
+          for (const n of r.removedNodes) if (involvesImage(n)) {
+            lastChangeAt = Date.now();
+            return;
+          }
+        }
+      }
+    });
     observer.observe(document.documentElement, {
       childList: true,
       subtree: true,

--- a/packages/backend/src/services/capture/pageReadyDetector.ts
+++ b/packages/backend/src/services/capture/pageReadyDetector.ts
@@ -1,0 +1,244 @@
+import type { Page } from "playwright";
+
+export type SignalOutcome = "fired" | "timeout";
+
+export interface ReadinessReport {
+  images: SignalOutcome;
+  fonts: SignalOutcome;
+  backgroundImages: SignalOutcome;
+  animations: SignalOutcome;
+  videos: SignalOutcome;
+  requests: SignalOutcome;
+}
+
+export interface WaitUntilStableOptions {
+  imagesTimeoutMs?: number;
+  fontsTimeoutMs?: number;
+  backgroundImagesTimeoutMs?: number;
+  animationsTimeoutMs?: number;
+  videosTimeoutMs?: number;
+  requestsTimeoutMs?: number;
+  /** Quiet window for request-settling — resolves N ms after last response. */
+  requestSettleQuietWindowMs?: number;
+  /** Overall ceiling. Every per-signal timeout is clamped to this value, so
+   * the whole call returns within roughly this budget even if a signal hangs. */
+  overallTimeoutMs?: number;
+}
+
+const DEFAULT_SIGNAL_TIMEOUT_MS = 15_000;
+const DEFAULT_OVERALL_TIMEOUT_MS = 60_000;
+const DEFAULT_REQUEST_QUIET_WINDOW_MS = 500;
+
+export async function waitUntilStable(
+  page: Page,
+  opts: WaitUntilStableOptions = {}
+): Promise<ReadinessReport> {
+  const overall = opts.overallTimeoutMs ?? DEFAULT_OVERALL_TIMEOUT_MS;
+  const cap = (t: number) => Math.min(t, overall);
+
+  const imagesTimeoutMs = cap(opts.imagesTimeoutMs ?? DEFAULT_SIGNAL_TIMEOUT_MS);
+  const fontsTimeoutMs = cap(opts.fontsTimeoutMs ?? DEFAULT_SIGNAL_TIMEOUT_MS);
+  const backgroundImagesTimeoutMs = cap(
+    opts.backgroundImagesTimeoutMs ?? DEFAULT_SIGNAL_TIMEOUT_MS
+  );
+  const animationsTimeoutMs = cap(
+    opts.animationsTimeoutMs ?? DEFAULT_SIGNAL_TIMEOUT_MS
+  );
+  const videosTimeoutMs = cap(opts.videosTimeoutMs ?? DEFAULT_SIGNAL_TIMEOUT_MS);
+  const requestsTimeoutMs = cap(
+    opts.requestsTimeoutMs ?? DEFAULT_SIGNAL_TIMEOUT_MS
+  );
+  const requestQuietWindowMs =
+    opts.requestSettleQuietWindowMs ?? DEFAULT_REQUEST_QUIET_WINDOW_MS;
+
+  const [images, fonts, backgroundImages, animations, videos, requests] = await Promise.all([
+    runSignal(() => waitForAllImages(page), imagesTimeoutMs),
+    runSignal(() => waitForFonts(page), fontsTimeoutMs),
+    runSignal(() => waitForBackgroundImages(page), backgroundImagesTimeoutMs),
+    runSignal(() => settleAnimations(page), animationsTimeoutMs),
+    runSignal(() => waitForVideos(page), videosTimeoutMs),
+    runSignal(() => waitForRequestQuiet(page, requestQuietWindowMs), requestsTimeoutMs),
+  ]);
+
+  return { images, fonts, backgroundImages, animations, videos, requests };
+}
+
+async function runSignal(
+  signal: () => Promise<void>,
+  timeoutMs: number
+): Promise<SignalOutcome> {
+  return new Promise<SignalOutcome>((resolveOutcome) => {
+    const timer = setTimeout(() => resolveOutcome("timeout"), timeoutMs);
+    signal()
+      .then(() => {
+        clearTimeout(timer);
+        resolveOutcome("fired");
+      })
+      .catch(() => {
+        clearTimeout(timer);
+        resolveOutcome("timeout");
+      });
+  });
+}
+
+async function waitForRequestQuiet(page: Page, quietWindowMs: number): Promise<void> {
+  let lastResponseAt = Date.now();
+  const onResponse = () => {
+    lastResponseAt = Date.now();
+  };
+  page.on("response", onResponse);
+
+  try {
+    while (Date.now() - lastResponseAt < quietWindowMs) {
+      const remaining = quietWindowMs - (Date.now() - lastResponseAt);
+      await new Promise((resolveTick) => setTimeout(resolveTick, Math.max(remaining, 25)));
+    }
+  } finally {
+    page.off("response", onResponse);
+  }
+}
+
+async function waitForVideos(page: Page): Promise<void> {
+  await page.evaluate(async () => {
+    const videos = Array.from(document.querySelectorAll<HTMLVideoElement>("video"));
+    await Promise.all(
+      videos.map(async (video) => {
+        // 1. If the video has a source, wait for metadata so it lays out at
+        //    its intrinsic dimensions; otherwise this is a no-op.
+        if (video.readyState < 1 && (video.currentSrc || video.src)) {
+          await new Promise<void>((resolveMeta) => {
+            const settle = () => resolveMeta();
+            video.addEventListener("loadedmetadata", settle, { once: true });
+            video.addEventListener("error", settle, { once: true });
+          });
+        }
+        // 2. If the video has a poster, force-load and decode it so the still
+        //    is in the raster before screenshot.
+        const poster = video.getAttribute("poster");
+        if (poster) {
+          const absolute = new URL(poster, document.baseURI).toString();
+          await new Promise<void>((resolveLoad) => {
+            const img = new Image();
+            const settle = () => resolveLoad();
+            img.addEventListener("load", async () => {
+              try {
+                if (typeof img.decode === "function") await img.decode();
+              } catch {
+                /* ignore */
+              }
+              settle();
+            }, { once: true });
+            img.addEventListener("error", settle, { once: true });
+            img.src = absolute;
+          });
+        }
+      })
+    );
+  });
+}
+
+async function settleAnimations(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const style = document.createElement("style");
+    style.setAttribute("data-page-ready-detector", "animation-freeze");
+    style.textContent = `*, *::before, *::after {
+      animation-play-state: paused !important;
+      transition-duration: 0s !important;
+      transition-delay: 0s !important;
+    }`;
+    document.head.appendChild(style);
+
+    for (const anim of document.getAnimations()) {
+      try {
+        anim.pause();
+      } catch {
+        /* ignore */
+      }
+    }
+  });
+}
+
+async function waitForBackgroundImages(page: Page): Promise<void> {
+  await page.evaluate(async () => {
+    const urlPattern = /url\(\s*(?:"([^"]+)"|'([^']+)'|([^)\s]+))\s*\)/g;
+    const seen = new Set<string>();
+    const sources: string[] = [];
+
+    for (const el of Array.from(document.querySelectorAll<HTMLElement>("*"))) {
+      const style = getComputedStyle(el);
+      const bg = style.backgroundImage;
+      if (!bg || bg === "none") continue;
+      let m: RegExpExecArray | null;
+      urlPattern.lastIndex = 0;
+      while ((m = urlPattern.exec(bg))) {
+        const raw = m[1] ?? m[2] ?? m[3];
+        if (!raw || raw.startsWith("data:")) continue;
+        const absolute = new URL(raw, document.baseURI).toString();
+        if (!seen.has(absolute)) {
+          seen.add(absolute);
+          sources.push(absolute);
+        }
+      }
+    }
+
+    await Promise.all(
+      sources.map(
+        (src) =>
+          new Promise<void>((resolveLoad) => {
+            const img = new Image();
+            const settle = () => resolveLoad();
+            img.addEventListener("load", async () => {
+              try {
+                if (typeof img.decode === "function") await img.decode();
+              } catch {
+                /* decode rejects for broken images; treat as settled */
+              }
+              settle();
+            }, { once: true });
+            img.addEventListener("error", settle, { once: true });
+            img.src = src;
+          })
+      )
+    );
+  });
+}
+
+async function waitForFonts(page: Page): Promise<void> {
+  await page.evaluate(async () => {
+    if (!document.fonts) return;
+    // Fast path: if the FontFaceSet is already settled, do not wait on
+    // document.fonts.ready — some browsers defer that promise's resolution
+    // until the document itself reaches "loaded", which is too coupled to
+    // unrelated page-load progress.
+    if (document.fonts.status === "loaded" && document.fonts.size === 0) {
+      return;
+    }
+    if (typeof document.fonts.ready?.then === "function") {
+      await document.fonts.ready;
+    }
+  });
+}
+
+async function waitForAllImages(page: Page): Promise<void> {
+  await page.evaluate(async () => {
+    const imgs = Array.from(document.images);
+    await Promise.all(
+      imgs.map(async (img) => {
+        if (!(img.complete && img.naturalWidth > 0)) {
+          await new Promise<void>((resolveImg) => {
+            const settle = () => resolveImg();
+            img.addEventListener("load", settle, { once: true });
+            img.addEventListener("error", settle, { once: true });
+          });
+        }
+        if (typeof img.decode === "function") {
+          try {
+            await img.decode();
+          } catch {
+            // decode rejects for broken images; treat as settled
+          }
+        }
+      })
+    );
+  });
+}

--- a/packages/backend/src/services/manifestBuilder.ts
+++ b/packages/backend/src/services/manifestBuilder.ts
@@ -25,6 +25,7 @@ function serializePage(row: typeof pages.$inferSelect): Record<string, unknown> 
     annotatedScreenshotPath: row.annotatedScreenshotPath ?? null,
     interactiveElements: parseJson<unknown[]>(row.interactiveElements, []),
     globalStyles: parseJson<Record<string, unknown> | null>(row.globalStyles, null),
+    viewportWidth: row.viewportWidth ?? null,
     lastCrawledAt: row.lastCrawledAt?.toISOString() ?? null,
     lastCrawlJobId: row.lastCrawlJobId ?? null,
     createdAt: row.createdAt.toISOString(),

--- a/packages/backend/src/workers/handlers/crawlJobHandler.ts
+++ b/packages/backend/src/workers/handlers/crawlJobHandler.ts
@@ -81,7 +81,7 @@ export async function crawlJobHandler(job: Job): Promise<unknown> {
       url,
       publicUrl,
       maxRequestsPerCrawl,
-      deviceScaleFactor || 1,
+      deviceScaleFactor || 2,
       job.id,
       delay || 0,
       requestDelay || 1000,

--- a/packages/plugin/src/constants/index.ts
+++ b/packages/plugin/src/constants/index.ts
@@ -4,7 +4,7 @@ export const DEFAULT_SETTINGS: PluginSettings = {
   url: "",
   maxRequests: "10",
   screenshotWidth: "1440",
-  deviceScaleFactor: "1",
+  deviceScaleFactor: "2",
   delay: "0",
   requestDelay: "1000",
   maxDepth: "0",

--- a/packages/plugin/src/figmaRendering/utils/createScreenshotPages.ts
+++ b/packages/plugin/src/figmaRendering/utils/createScreenshotPages.ts
@@ -794,9 +794,19 @@ export async function createScreenshotPages(
       navFrame.resize(screenshotWidth, navHeight);
       overlayContainer.appendChild(navFrame);
 
-      // Compute scaling factor once (for both interactive and style elements)
+      // Compute scaling factor once (for both interactive and style elements).
+      // The backend records CSS viewport width separately from the raw image
+      // pixel width. Prefer CSS viewport when present — at DPR > 1 the image
+      // is wider than the viewport, and using image.width here scales element
+      // bboxes (in CSS px) incorrectly. Fall back to image width for legacy
+      // captures that pre-date the viewportWidth field.
       const referenceShot = loadedScreenshots[0];
-      const originalWidth = referenceShot?.width || screenshotWidth;
+      const originalWidth =
+        (page.viewportWidth && Number.isFinite(page.viewportWidth) && page.viewportWidth > 0
+          ? page.viewportWidth
+          : null) ??
+        referenceShot?.width ??
+        screenshotWidth;
       const scaleFactor =
         originalWidth > 0 ? screenshotWidth / originalWidth : 1;
 

--- a/packages/plugin/src/plugin/services/apiClient.ts
+++ b/packages/plugin/src/plugin/services/apiClient.ts
@@ -21,6 +21,9 @@ interface PageResponseItem {
     text?: string;
   }>;
   globalStyles?: Record<string, unknown> | null;
+  /** CSS viewport width at capture time, set by the backend. Distinct from
+   * the raw image pixel width (viewport × DPR). Used for overlay scaling. */
+  viewportWidth?: number | null;
   createdAt?: string;
   updatedAt?: string;
 }
@@ -79,7 +82,7 @@ export async function startCrawl(params: CrawlParams): Promise<{ jobId: string }
     showBrowser: params.showBrowser,
     auth: params.auth,
     publicUrl: BACKEND_URL,
-    deviceScaleFactor: params.deviceScaleFactor || 1,
+    deviceScaleFactor: params.deviceScaleFactor || 2,
     delay: params.delay || 0,
     requestDelay: params.requestDelay || 1000,
     defaultLanguageOnly: params.defaultLanguageOnly !== false,
@@ -101,7 +104,7 @@ export async function recrawlPage(params: RecrawlParams): Promise<{ jobId: strin
     url: params.url,
     publicUrl: BACKEND_URL,
     projectId: params.projectId,
-    deviceScaleFactor: params.deviceScaleFactor || 1,
+    deviceScaleFactor: params.deviceScaleFactor || 2,
     delay: params.delay || 0,
     requestDelay: params.requestDelay || 1000,
     auth: params.auth,
@@ -313,7 +316,7 @@ export async function startApprovedCrawl(params: {
     approvedUrls: params.approvedUrls,
     fullRefresh: params.fullRefresh ?? true,
     screenshotWidth: params.screenshotWidth ?? 1440,
-    deviceScaleFactor: params.deviceScaleFactor ?? 1,
+    deviceScaleFactor: params.deviceScaleFactor ?? 2,
     auth: params.auth,
     cookieBannerHandling: params.cookieBannerHandling ?? "auto",
     styleExtraction: params.styleExtraction,

--- a/packages/plugin/src/plugin/utils/buildManifestFromProject.ts
+++ b/packages/plugin/src/plugin/utils/buildManifestFromProject.ts
@@ -20,6 +20,7 @@ export interface PageRecord {
     text?: string;
   }>;
   globalStyles?: Record<string, unknown> | null;
+  viewportWidth?: number | null;
   createdAt?: string;
   updatedAt?: string;
 }
@@ -372,6 +373,7 @@ function buildTreeFromPages(
       screenshot: screenshotPaths,
       thumbnail: screenshotPaths[0] || "",
       pageId: page._id,
+      viewportWidth: page.viewportWidth ?? null,
       children: [],
       interactiveElements: interactive,
       styleData: {

--- a/packages/plugin/src/types/index.ts
+++ b/packages/plugin/src/types/index.ts
@@ -139,6 +139,10 @@ export interface TreeNode {
   pageId?: string;
   children: TreeNode[];
   interactiveElements?: InteractiveElement[];
+  /** CSS viewport width recorded by the backend at capture time. Used to
+   * scale element bboxes against the on-canvas frame width. Distinct from
+   * the raw image pixel width (viewport × DPR). */
+  viewportWidth?: number | null;
   styleData?: {
     elements?: ExtractedElement[];
     cssVariables?: Record<string, unknown> | null;

--- a/packages/plugin/src/utils/validation.ts
+++ b/packages/plugin/src/utils/validation.ts
@@ -18,8 +18,8 @@ export function parseScreenshotWidth(screenshotWidth: string): number {
 
 export function parseDeviceScaleFactor(deviceScaleFactor: string): number {
   const value =
-    deviceScaleFactor.trim() === "" ? 1 : parseInt(deviceScaleFactor);
-  return isNaN(value) || value < 1 || value > 2 ? 1 : value;
+    deviceScaleFactor.trim() === "" ? 2 : parseInt(deviceScaleFactor);
+  return isNaN(value) || value < 1 || value > 2 ? 2 : value;
 }
 
 export function parseDelay(delay: string): number {


### PR DESCRIPTION
Closes #4 (and its child slices #5, #6, #7, #8). Seven commits, four issues closed, 44 unit + integration tests.

## Summary

- **Viewport bumped to 1920×1080** at the persistent-context level.
- **DPR 2 by default** — Crawlee's persistent context now sets `deviceScaleFactor` via `launchContext.launchOptions`, which is the only place that survives Crawlee's context lifecycle (the per-page CDP override and the `--device-scale-factor` chromium flag both lose to context defaults).
- **Plugin overlay scaling fixed** — backend records CSS viewport width on each page row; plugin uses that instead of raw image pixel width when computing overlay scale. Fixes the bug that broke the first attempt at DPR 2 in #5.
- **PageReadyDetector** deep module composes six readiness signals (image decode, web fonts, CSS background images, animation settling, video posters, custom request-settling) plus DOM-stability for late-hydrated content. Per-signal timeouts plus an overall ceiling that clamps every per-signal budget. Never throws.
- **LazyContentTrigger** replaces the inline fixed-step scroll loop with settle-based stepping bounded by step + time budgets, returns scrolled to top.
- **HighFidelityCapture** orchestrator collapses the inline pre-screenshot sequence (cookie banners + sticky-hide + lazy + scroll + readiness + screenshot) to a single named module with one call site in \`crawler.ts\`.
- **Playwright + static-HTTP fixture test harness** under \`packages/backend/src/services/capture/__fixtures__/\` — first test infra in the backend beyond co-located unit tests. Vitest runs it via the existing \`pnpm --filter backend test\` script.

## Headline behaviour change

Captures are sharper and more complete:

- Screenshots are now ~3840 wide at the default 1920 viewport (was 1440, then briefly 1920). Image data is denser than the on-canvas frame width → noticeably crisper at native zoom in Figma.
- Lazy-loaded sections lower on the page now render fully where they previously came out blank.
- React-hydrated content (cards, stats, illustrations) renders where it was missing before — covered by the DOM-stability poll loop with a narrowed MutationObserver that only reacts to image-relevant mutations.
- Animations are captured in a settled state instead of a random mid-frame.

## Commits

1. \`e67d9fb\` Bump capture viewport to 1920×1080
2. \`97f85d3\` Add PageReadyDetector deep module
3. \`5eb91e3\` PageReadyDetector waits for late-hydrated images
4. \`b4493df\` Narrow image-decode MutationObserver to image-relevant changes
5. \`e271e4e\` Add LazyContentTrigger settle-based scroll strategy
6. \`a62d52a\` Enable DPR 2 with correct overlay scaling
7. \`05b6b58\` Extract HighFidelityCapture orchestrator

## Schema change

New column \`pages.viewport_width INTEGER\` (nullable). Idempotent ALTER in \`db.ts\` for existing local DBs. Legacy captures without the column fall back to image-width-derived scaling so nothing breaks in place.

## Test plan

- [ ] Pull \`v0.3\`, install, restart the worker.
- [ ] Run a fresh crawl on a non-hostile site (vercel.com, linear.app). Confirm:
  - [ ] Worker log shows \`📸 Captured ... at viewport 1920x1080 @ DPR 2 (raster 3840xN)\`.
  - [ ] Worker log shows \`🟢 Readiness for ...: images=fired fonts=fired ...\`.
  - [ ] In Figma, screenshots look visibly sharper at native zoom than v0.2.
  - [ ] Element overlays / markup / inventory sample anchors land in correct positions (this was the bug from the failed first DPR-2 attempt in #5).
  - [ ] Lazy sections lower on the page are rendered, not blank.
- [ ] \`pnpm --filter backend test\` — 44 tests pass.

## Out of scope (worth filing as separate issues if they matter)

- **Anti-bot evasion** — Cloudflare-protected sites (atera.com, airtable.com) serve our crawler degraded HTML or 403 their own asset URLs. Independent of capture quality; requires fingerprint / behavioral / proxy work.
- **Lottie / canvas / iframe content** — interactive widgets that don't render statically. Some can be partially captured with specialised waits; some fundamentally can't.
- **Cookie banner dismissal refactor** — \`handleCookieConsentBanner\` is invoked from the orchestrator but its internals are unchanged per #8 AC.
- **Limited sticky-element selector** — current selector only matches \`.sticky\`, \`.fixed\`, or inline \`position:fixed/sticky\`. Misses computed-style stickies on real sites. Preserved as-is per #8 AC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)